### PR TITLE
Bump parent pom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>uk.gov.ons.ctp.product</groupId>
     <artifactId>rm-common-config</artifactId>
-    <version>10.49.1</version>
+    <version>10.49.6</version>
   </parent>
 
   <dependencies>


### PR DESCRIPTION
The parent pom has been updated to point to an external artifactory
domain for access from travis. Pointing to the latest pom will mean
artifacts are pushed via the correct domain